### PR TITLE
Sync app list with Discovery server.

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -32,12 +32,12 @@ type kvstorage struct {
 // 	AppName string `json:"app_name"`
 // }
 type appDiscoveryMeta struct {
-	ID        string `yaml:"id"`
-	AppName   string `yaml:"app_name"`
-	Addr      string `yaml:"addr"`
-	AppMode   string `yaml:"app_mode"`
-	HasChat   bool   `yaml:"has_chat"`
-	PageTitle string `yaml:"page_title"`
+	ID        string `json:"id"`
+	AppName   string `json:"app_name"`
+	Addr      string `json:"addr"`
+	AppMode   string `json:"app_mode"`
+	HasChat   bool   `json:"has_chat"`
+	PageTitle string `json:"page_title"`
 }
 
 type appDiscovery struct {
@@ -124,7 +124,7 @@ func (d *appDiscovery) addApp(h appDiscoveryMeta) (string, error) {
 
 func (d *appDiscovery) removeApp(appID string) error {
 	ctx, _ := context.WithTimeout(context.Background(), requestTimeout)
-	return d.storage.removeValue(ctx, appID)
+	return d.storage.removeValue(ctx, appHostPrefix+appID)
 }
 
 func (d *appDiscovery) getApps() []appDiscoveryMeta {

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	dialTimeout    = 2 * time.Second
-	requestTimeout = 10 * time.Second
+	requestTimeout = 2 * time.Second
 )
 const addr string = ":7700"
 const etcdAddr string = ":2379"
@@ -172,7 +172,7 @@ func (s *server) register(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) remove(w http.ResponseWriter, r *http.Request) {
-	log.Println("Received remove Request")
+	log.Println("Received removes Request")
 	var appID string
 	// Try to decode the request body into the struct. If there is an error,
 	// respond to the client with the error message and a 400 status code.
@@ -198,6 +198,7 @@ func (s *server) getApps(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("Received GetApps Request")
 	encodedResp, err := json.Marshal(resp)
+	log.Println(encodedResp)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/server.go
+++ b/server.go
@@ -197,12 +197,6 @@ func NewServer() *Server {
 		discoveryHandler: NewDiscovery(cfg.DiscoveryHost),
 	}
 
-	// templateData := TemplateData{
-	// 	Chat:          cfg.HasChat,
-	// 	PageTitle:     cfg.PageTitle,
-	// 	Collaborative: cfg.AppMode == "collaborative",
-	// }
-
 	r := mux.NewRouter()
 	r.HandleFunc("/ws", server.WS)
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./web"))))

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"log"
 	"net/http"
 	"net/http/pprof"
+	"os"
+	"os/signal"
 	"time"
 
 	"github.com/giongto35/cloud-morph/pkg/addon/textchat"
@@ -44,38 +47,27 @@ type Client struct {
 }
 
 type Server struct {
-	httpServer *http.Server
-	clients    map[string]*Client
-	cgame      *cloudgame.Service
-	chat       *textchat.TextChat
+	appID            string
+	httpServer       *http.Server
+	clients          map[string]*Client
+	cgame            *cloudgame.Service
+	chat             *textchat.TextChat
+	discoveryHandler *discoveryHandler
 }
 
-type TemplateData struct {
-	Chat          bool
-	PageTitle     string
-	Collaborative bool
+type discoveryHandler struct {
+	httpClient    *http.Client
+	discoveryHost string
+	apps          []appDiscoveryMeta
 }
 
-// GetWeb returns web frontend
-func (o *Server) GetWebWithData(templateData TemplateData) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		tmpl, err := template.ParseFiles(indexPage)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		tmpl.Execute(w, templateData)
-	}
+type appDiscoveryMeta struct {
+	ID        string `yaml:"id"`
+	Addr      string `yaml:"addr"`
+	AppMode   string `yaml:"app_mode"`
+	HasChat   bool   `yaml:"has_chat"`
+	PageTitle string `yaml:"page_title"`
 }
-
-//GetWeb(w http.ResponseWriter, r *http.Request) {
-//tmpl, err := template.ParseFiles(indexPage)
-//if err != nil {
-//log.Fatal(err)
-//}
-
-//tmpl.Execute(w, templateData)
-//}
 
 // WSO handles all connections from user/frontend to coordinator
 func (s *Server) WS(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +123,7 @@ func (s *Server) WS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) ListenAppListUpdate() {
-	for updatedApps := range s.cgame.AppListUpdate() {
+	for updatedApps := range s.AppListUpdate() {
 		log.Println("Get updated apps: ", updatedApps, s.clients)
 		for _, client := range s.clients {
 			data, _ := json.Marshal(updatedApps)
@@ -193,25 +185,35 @@ func NewClient(c *websocket.Conn, clientID string) *Client {
 }
 
 func NewServer() *Server {
-	server := &Server{
-		clients: map[string]*Client{},
-	}
-
 	cfg, err := readConfig(configFilePath)
 	if err != nil {
 		panic(err)
 	}
 
-	templateData := TemplateData{
-		Chat:          cfg.HasChat,
-		PageTitle:     cfg.PageTitle,
-		Collaborative: cfg.AppMode == "collaborative",
+	server := &Server{
+		clients:          map[string]*Client{},
+		discoveryHandler: NewDiscovery(cfg.DiscoveryHost),
 	}
+
+	// templateData := TemplateData{
+	// 	Chat:          cfg.HasChat,
+	// 	PageTitle:     cfg.PageTitle,
+	// 	Collaborative: cfg.AppMode == "collaborative",
+	// }
 
 	r := mux.NewRouter()
 	r.HandleFunc("/ws", server.WS)
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./web"))))
-	r.PathPrefix("/").HandlerFunc(server.GetWebWithData(templateData))
+	r.PathPrefix("/").HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			tmpl, err := template.ParseFiles(indexPage)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			tmpl.Execute(w, nil)
+		},
+	)
 
 	svmux := &http.ServeMux{}
 	svmux.Handle("/", r)
@@ -229,8 +231,19 @@ func NewServer() *Server {
 	// Launch Game VM
 	server.cgame = cloudgame.NewCloudService(cfg)
 	server.chat = textchat.NewTextChat()
+	appID, err := server.RegisterApp(appDiscoveryMeta{
+		Addr:      addr,
+		AppMode:   cfg.AppMode,
+		HasChat:   cfg.HasChat,
+		PageTitle: cfg.PageTitle,
+	})
+	server.appID = appID
 
 	return server
+}
+
+func (o *Server) Shutdown() {
+	o.RemoveApp(o.appID)
 }
 
 func readConfig(path string) (config.Config, error) {
@@ -295,6 +308,17 @@ func main() {
 	monitor()
 	server := NewServer()
 	server.Handle()
+
+	go func() {
+		stop := make(chan os.Signal, 1)
+		signal.Notify(stop, os.Interrupt)
+		select {
+		case <-stop:
+			fmt.Println("Received SIGTERM, Quiting")
+			server.Shutdown()
+		}
+	}()
+
 	err := server.ListenAndServe()
 	if err != nil {
 		log.Fatal(err)
@@ -324,4 +348,113 @@ func Decode(in string, obj interface{}) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func NewDiscovery(discoveryHost string) *discoveryHandler {
+	return &discoveryHandler{
+		httpClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
+		discoveryHost: discoveryHost,
+	}
+}
+
+func (s *Server) GetApps() []appDiscoveryMeta {
+	return s.discoveryHandler.GetApps()
+}
+
+func (s *Server) RegisterApp(meta appDiscoveryMeta) (string, error) {
+	return s.discoveryHandler.Register(meta)
+}
+
+func (s *Server) RemoveApp(appID string) error {
+	return s.discoveryHandler.Remove(s.appID)
+}
+
+func (s *Server) AppListUpdate() chan []appDiscoveryMeta {
+	return s.discoveryHandler.AppListUpdate()
+}
+
+func (d *discoveryHandler) GetApps() []appDiscoveryMeta {
+	type GetAppsResponse struct {
+		apps []appDiscoveryMeta `json:"apps"`
+	}
+	var resp GetAppsResponse
+
+	rawResp, err := d.httpClient.Get(d.discoveryHost + "/get-apps")
+	if err != nil {
+		log.Println(err)
+		return []appDiscoveryMeta{}
+	}
+
+	defer rawResp.Body.Close()
+	json.NewDecoder(rawResp.Body).Decode(&resp)
+
+	return resp.apps
+}
+
+func (d *discoveryHandler) isNeedAppListUpdate(newApps []appDiscoveryMeta) bool {
+	if len(newApps) != len(d.apps) {
+		return true
+	}
+
+	for i, app := range newApps {
+		if app != d.apps[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *discoveryHandler) AppListUpdate() chan []appDiscoveryMeta {
+	updatedApps := make(chan []appDiscoveryMeta, 1)
+	go func() {
+		// TODO: Change to subscription based
+		for range time.Tick(5 * time.Second) {
+			newApps := d.GetApps()
+			if d.isNeedAppListUpdate(newApps) {
+				log.Println("Update AppHosts: ", newApps)
+				updatedApps <- newApps
+				d.apps = make([]appDiscoveryMeta, len(newApps))
+				copy(d.apps, newApps)
+			}
+		}
+	}()
+
+	return updatedApps
+}
+
+func (d *discoveryHandler) Register(meta appDiscoveryMeta) (string, error) {
+	reqBytes, err := json.Marshal(meta)
+	if err != nil {
+		return "", nil
+	}
+
+	resp, err := d.httpClient.Post(d.discoveryHost+"/register", "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return "", nil
+	}
+	var appID string
+	err = json.NewDecoder(resp.Body).Decode(&appID)
+	if err != nil {
+		return "", nil
+	}
+
+	return appID, nil
+}
+
+func (d *discoveryHandler) Remove(appID string) error {
+	reqBytes, err := json.Marshal(appID)
+	if err != nil {
+		return nil
+	}
+
+	_, err = d.httpClient.Post(d.discoveryHost+"/remove", "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil
+	}
+
+	return err
+
 }

--- a/server.go
+++ b/server.go
@@ -243,7 +243,12 @@ func NewServer() *Server {
 }
 
 func (o *Server) Shutdown() {
-	o.RemoveApp(o.appID)
+	fmt.Println("send remove")
+	err := o.RemoveApp(o.appID)
+	fmt.Println("Removed")
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func readConfig(path string) (config.Config, error) {
@@ -382,12 +387,12 @@ func (d *discoveryHandler) GetApps() []appDiscoveryMeta {
 	var resp GetAppsResponse
 
 	rawResp, err := d.httpClient.Get(d.discoveryHost + "/get-apps")
+	fmt.Println(rawResp)
 	if err != nil {
 		log.Println(err)
 		return []appDiscoveryMeta{}
 	}
 
-	defer rawResp.Body.Close()
 	json.NewDecoder(rawResp.Body).Decode(&resp)
 
 	return resp.apps
@@ -412,7 +417,9 @@ func (d *discoveryHandler) AppListUpdate() chan []appDiscoveryMeta {
 	go func() {
 		// TODO: Change to subscription based
 		for range time.Tick(5 * time.Second) {
+			fmt.Println("getting apps")
 			newApps := d.GetApps()
+			fmt.Println("newApps", newApps)
 			if d.isNeedAppListUpdate(newApps) {
 				log.Println("Update AppHosts: ", newApps)
 				updatedApps <- newApps

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>{{.PageTitle}}</title>
+    <title>Cloud Morph Demo</title>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <link href="/static/css/main.css" rel="stylesheet" />
@@ -16,9 +16,7 @@
         onloadstart="this.volume=0.5" autoplay></video>
       <div id="game-meta">
         <label id="intro">Collaborative play Diablo. Communicate with other and try to defeat Diablo.</label></br>
-        {{if .Collaborative}}
         <label id="numplayers">Number of players:</label></br>
-        {{end}}
         <select class="drop" id="discoverydropdown">
         </select>
         <button id="fullscreen" type="submit">Toggle chat</button>
@@ -27,20 +25,18 @@
         <p>Built by <a href=https://www.linkedin.com/in/huuthanhnguyen />giongto35</a></p>
       </div>
     </div>
-    {{if .Chat}}
-        <div id="chat">
-          <pre id="chatoutput" class="messages"></pre>
-          <div id="chatprofile">
-            <label id="usernamelabel">UserName</label>
-            <input id="chatusername" type="text" placeholder="Enter User Name to join" />
-          </div>
-          <div id="chatinput">
-            <label id="messagelabel">Message</label>
-            <textarea id="chatmessage" placeholder="Start typing the message" rows="3"></textarea>
-          </div>
-          <button id="chatsubmit" type="submit">Send</button>
+      <div id="chat">
+        <pre id="chatoutput" class="messages"></pre>
+        <div id="chatprofile">
+          <label id="usernamelabel">UserName</label>
+          <input id="chatusername" type="text" placeholder="Enter User Name to join" />
         </div>
-    {{end}}
+        <div id="chatinput">
+          <label id="messagelabel">Message</label>
+          <textarea id="chatmessage" placeholder="Start typing the message" rows="3"></textarea>
+        </div>
+        <button id="chatsubmit" type="submit">Send</button>
+      </div>
 
     <script src="/static/js/game.js"></script>
   </div>

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -253,7 +253,6 @@ function updateNumPlayers(data) {
 function updateAppList(data) {
   appList = JSON.parse(data.data);
   discoverydropdown.innerHTML = "";
-  console.log("Update", data);
   for (app of appList) {
     appEntry = document.createElement("option");
     appEntry.innerText = app.app_name

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -252,6 +252,8 @@ function updateNumPlayers(data) {
 
 function updateAppList(data) {
   appList = JSON.parse(data.data);
+  discoverydropdown.innerHTML = "";
+  console.log("Update", data);
   for (app of appList) {
     appEntry = document.createElement("option");
     appEntry.innerText = app.app_name

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -15,6 +15,7 @@ const gamed = document.getElementById("game");
 const chatd = document.getElementById("chat");
 const numplayers = document.getElementById("numplayers");
 const discoverydropdown = document.getElementById("discoverydropdown");
+const appTitle = document.getElementById("appTitle");
 
 var offerst;
 // const offer = new RTCSessionDescription(JSON.parse(atob(data)));
@@ -137,6 +138,7 @@ document.addEventListener("keyup", (e) => {
 discoverydropdown.addEventListener("change", () => {
   app = appList[discoverydropdown.selectedIndex];
   connect("http", app.addr)
+  updatePage(app)
 })
 
 // Add the event listeners for mousedown, mousemove, and mouseup
@@ -255,6 +257,12 @@ function updateAppList(data) {
     appEntry.innerText = app.app_name
     discoverydropdown.appendChild(appEntry);
   }
+}
+
+function updatePage(app) {
+  chatd.style.visibility = app.hasChat
+  appTitle.innerText = app.pageTitle
+  numplayers.style.visibility = app.collaborative;
 }
 
 function updateAnswer(data) {

--- a/winvm/sendkey.cpp
+++ b/winvm/sendkey.cpp
@@ -263,7 +263,6 @@ void *healthcheck(void *args)
 void processEvent(HWND hwnd, string ev, bool isDxGame)
 {
     // Mouse payload
-    cout << "Got: " << ev << endl;
     if (ev[0] == 'K')
     {
         Key key = parseKeyPayload(ev.substr(1, ev.length() - 1));


### PR DESCRIPTION
- When a cloudapp shuts down, delete the entry in Discovery server.
- Refactor, bring discoveryClient to server.go