### PR TITLE
small fixes dockerfile - wine version - add-apt autoconfirm - rmove c…

### DIFF
--- a/winvm/Dockerfile
+++ b/winvm/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get install --no-install-recommends --assume-yes wget software-propertie
 RUN dpkg --add-architecture i386
 RUN wget -O - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
 RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main' 
-RUN add-apt-repository ppa:cybermax-dexter/sdl2-backport
+
+
+RUN add-apt-repository -y  ppa:cybermax-dexter/sdl2-backport
 
 RUN aptitude install -y winehq-stable
 
@@ -28,8 +30,9 @@ RUN winetricks d3dx9_43
 
 # Download gecko and mono installers
 COPY download_gecko_and_mono.sh /root/download_gecko_and_mono.sh
-RUN chmod +x /root/download_gecko_and_mono.sh \
-    && /root/download_gecko_and_mono.sh "$(dpkg -s wine-stable | grep "^Version:\s" | awk '{print $2}' | sed -E 's/~.*$//')"
+
+RUN  sed 's/\r//' /root/download_gecko_and_mono.sh > /root/download_gecko_and_mono_.sh && chmod +x /root/download_gecko_and_mono_.sh \
+    && /root/download_gecko_and_mono_.sh "$(dpkg -s winehq-stable | grep "^Version:\s" | awk '{print $2}' | sed -E 's/~.*$//')"
 
 RUN mkdir -p /winvm
 WORKDIR /winvm


### PR DESCRIPTION
Hi, you don't have to merge this,  this pull request is more like a question,  i don't know if i'm building the image right,
but i'm having some problems so i changed the dockerfile

(1) line 16  add-apt-repository   asks confirmation  and blocks the docker build
so i changed it  to  `add-apt-repository -y`

(2) line 31 - `dpkg -s wine-stable`  fails  because  the package name is actually called winehq-stable

(3) other problem for windows users (that's why i said you don't  have to merge this)
git clone add carriage returns that make the build crush, so just to be safe  i added sed 's/\r//'